### PR TITLE
Add logo files without text

### DIFF
--- a/docs/src/assets/logo-circle-dark.svg
+++ b/docs/src/assets/logo-circle-dark.svg
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="54.999996mm"
+   height="55mm"
+   viewBox="0 0 55 55.000002"
+   version="1.1"
+   id="svg5"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2" />
+  <g
+     id="layer1"
+     transform="translate(-3.8200512,-38.875282)"
+     style="display:inline">
+    <circle
+       style="font-variation-settings:normal;opacity:1;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       id="path2228"
+       cx="31.320051"
+       cy="66.375282"
+       r="27" />
+    <circle
+       style="fill:#389826;fill-opacity:1;fill-rule:evenodd;stroke-width:0.271583"
+       id="path239"
+       cx="20.791399"
+       cy="57.799713"
+       r="10.264584" />
+    <ellipse
+       style="fill:#cb3c33;fill-opacity:1;fill-rule:evenodd;stroke-width:0.271582"
+       id="path239-6"
+       cx="29.275663"
+       cy="79.081497"
+       rx="10.2645"
+       ry="10.264584" />
+    <ellipse
+       style="fill:#9558b2;fill-opacity:1;fill-rule:evenodd;stroke-width:0.271582"
+       id="path239-6-7"
+       cx="44.204033"
+       cy="61.426746"
+       rx="10.2645"
+       ry="10.264584" />
+  </g>
+</svg>

--- a/docs/src/assets/logo-circle.svg
+++ b/docs/src/assets/logo-circle.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="55mm"
+   height="55mm"
+   viewBox="0 0 55.000004 55.000002"
+   version="1.1"
+   id="svg5"
+   sodipodi:docname="logo.svg"
+   inkscape:export-filename="logo.svg"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview27"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="1.6531147"
+     inkscape:cx="251.04126"
+     inkscape:cy="68.053354"
+     inkscape:window-width="1978"
+     inkscape:window-height="1083"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg5" />
+  <defs
+     id="defs2" />
+  <g
+     id="layer1"
+     transform="translate(-3.8200512,-38.875282)"
+     style="display:inline">
+    <circle
+       style="font-variation-settings:normal;opacity:1;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       id="path2228"
+       cx="31.320051"
+       cy="66.375282"
+       r="27" />
+    <circle
+       style="fill:#389826;fill-opacity:1;fill-rule:evenodd;stroke-width:0.271583"
+       id="path239"
+       cx="20.791399"
+       cy="57.799713"
+       r="10.264584" />
+    <ellipse
+       style="fill:#cb3c33;fill-opacity:1;fill-rule:evenodd;stroke-width:0.271582"
+       id="path239-6"
+       cx="29.275663"
+       cy="79.081497"
+       rx="10.2645"
+       ry="10.264584" />
+    <ellipse
+       style="fill:#9558b2;fill-opacity:1;fill-rule:evenodd;stroke-width:0.271582"
+       id="path239-6-7"
+       cx="44.204033"
+       cy="61.426746"
+       rx="10.2645"
+       ry="10.264584" />
+  </g>
+</svg>

--- a/docs/src/assets/logo-notext-dark.svg
+++ b/docs/src/assets/logo-notext-dark.svg
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="113.82925mm"
+   height="104.96313mm"
+   viewBox="0 0 113.82926 104.96313"
+   version="1.1"
+   id="svg5"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2" />
+  <g
+     id="layer3"
+     style="display:inline">
+    <path
+       style="display:inline;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 78.159193,48.431919 117.40179,70.789843"
+       id="path3096-3"
+       transform="translate(-3.8200513,-4.2478129)" />
+  </g>
+  <g
+     id="layer2"
+     style="display:none">
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:45.8611px;line-height:1.25;font-family:sans-serif;letter-spacing:-2.64583px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="51.03138"
+       y="100.15723"
+       id="text4511"><tspan
+         id="tspan4509"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:45.8611px;font-family:'Tamil MN';-inkscape-font-specification:'Tamil MN';stroke-width:0.264583"
+         x="51.03138"
+         y="100.15723">Juleana</tspan></text>
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:1.00074;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 74.642682,40.320073 209.56102,69.660303"
+       id="path3096-5" />
+  </g>
+  <g
+     id="layer1"
+     transform="translate(-3.8200512,-4.247813)"
+     style="display:inline">
+    <circle
+       style="font-variation-settings:normal;opacity:1;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       id="path2228"
+       cx="31.320051"
+       cy="66.375282"
+       r="27" />
+    <circle
+       style="font-variation-settings:normal;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+       id="path2228-2"
+       cx="-53.782318"
+       cy="-67.712936"
+       r="27"
+       transform="rotate(150)" />
+    <circle
+       style="fill:#389826;fill-opacity:1;fill-rule:evenodd;stroke-width:0.271583"
+       id="path239"
+       cx="20.791399"
+       cy="57.799713"
+       r="10.264584" />
+    <ellipse
+       style="fill:#cb3c33;fill-opacity:1;fill-rule:evenodd;stroke-width:0.271582"
+       id="path239-6"
+       cx="29.275663"
+       cy="79.081497"
+       rx="10.2645"
+       ry="10.264584" />
+    <circle
+       style="fill:#389826;fill-opacity:1;fill-rule:evenodd;stroke-width:0.271583"
+       id="path239-2"
+       cx="64.310974"
+       cy="76.288483"
+       r="10.264584"
+       transform="rotate(-30)" />
+    <ellipse
+       style="fill:#cb3c33;fill-opacity:1;fill-rule:evenodd;stroke-width:0.271582"
+       id="path239-6-8"
+       cx="55.826706"
+       cy="55.006737"
+       rx="10.2645"
+       ry="10.264584"
+       transform="rotate(-30)" />
+    <path
+       style="fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:4, 2;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 53.977047,64.626543 c 1.896622,0.473878 3.909735,0.473878 5.806357,0 3.731608,-0.932357 6.931859,-3.777064 8.290967,-7.37526 0.645911,-1.710029 0.892005,-3.569642 0.713137,-5.388819"
+       id="path2815" />
+    <path
+       style="fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 45.824023,64.647305 7.853886,44.476685"
+       id="path3096" />
+    <ellipse
+       style="fill:#9558b2;fill-opacity:1;fill-rule:evenodd;stroke-width:0.271582"
+       id="path239-6-7"
+       cx="44.204033"
+       cy="60.897579"
+       rx="10.2645"
+       ry="10.264584" />
+    <ellipse
+       style="fill:#9558b2;fill-opacity:1;fill-rule:evenodd;stroke-width:0.271582"
+       id="path239-6-7-4"
+       cx="40.898346"
+       cy="73.190628"
+       rx="10.2645"
+       ry="10.264584"
+       transform="rotate(-30)" />
+  </g>
+</svg>

--- a/docs/src/assets/logo-notext.svg
+++ b/docs/src/assets/logo-notext.svg
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="113.82925mm"
+   height="104.96313mm"
+   viewBox="0 0 113.82926 104.96313"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   sodipodi:docname="juleana-logo-inkscape.svg"
+   inkscape:export-filename="logo-notext.svg"
+   inkscape:export-xdpi="96.919998"
+   inkscape:export-ydpi="96.919998"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="true"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="0.71377274"
+     inkscape:cx="221.35897"
+     inkscape:cy="346.04852"
+     inkscape:window-width="1920"
+     inkscape:window-height="1011"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:clip-to-page="false" />
+  <defs
+     id="defs2">
+    <inkscape:path-effect
+       effect="spiro"
+       id="path-effect2817"
+       is_visible="true"
+       lpeversion="1" />
+  </defs>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="NoText"
+     style="display:inline">
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 78.159193,48.431919 117.40179,70.789843"
+       id="path3096-3"
+       transform="translate(-3.8200513,-4.2478129)" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Text"
+     style="display:none">
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:45.8611px;line-height:1.25;font-family:sans-serif;letter-spacing:-2.64583px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="51.03138"
+       y="100.15723"
+       id="text4511"><tspan
+         sodipodi:role="line"
+         id="tspan4509"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:45.8611px;font-family:'Tamil MN';-inkscape-font-specification:'Tamil MN';stroke-width:0.264583"
+         x="51.03138"
+         y="100.15723">Juleana</tspan></text>
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:1.00074;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 74.642682,40.320073 209.56102,69.660303"
+       id="path3096-5" />
+  </g>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-3.8200512,-4.247813)"
+     style="display:inline">
+    <circle
+       style="font-variation-settings:normal;opacity:1;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       id="path2228"
+       cx="31.320051"
+       cy="66.375282"
+       r="27" />
+    <circle
+       style="font-variation-settings:normal;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+       id="path2228-2"
+       cx="-53.782318"
+       cy="-67.712936"
+       r="27"
+       transform="rotate(150)" />
+    <circle
+       style="fill:#389826;fill-opacity:1;fill-rule:evenodd;stroke-width:0.271583"
+       id="path239"
+       cx="20.791399"
+       cy="57.799713"
+       r="10.264584" />
+    <ellipse
+       style="fill:#cb3c33;fill-opacity:1;fill-rule:evenodd;stroke-width:0.271582"
+       id="path239-6"
+       cx="29.275663"
+       cy="79.081497"
+       rx="10.2645"
+       ry="10.264584" />
+    <circle
+       style="fill:#389826;fill-opacity:1;fill-rule:evenodd;stroke-width:0.271583"
+       id="path239-2"
+       cx="64.310974"
+       cy="76.288483"
+       r="10.264584"
+       transform="rotate(-30)" />
+    <ellipse
+       style="fill:#cb3c33;fill-opacity:1;fill-rule:evenodd;stroke-width:0.271582"
+       id="path239-6-8"
+       cx="55.826706"
+       cy="55.006737"
+       rx="10.2645"
+       ry="10.264584"
+       transform="rotate(-30)" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:4, 2;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 53.977047,64.626543 c 1.896622,0.473878 3.909735,0.473878 5.806357,0 3.731608,-0.932357 6.931859,-3.777064 8.290967,-7.37526 0.645911,-1.710029 0.892005,-3.569642 0.713137,-5.388819"
+       id="path2815"
+       inkscape:path-effect="#path-effect2817"
+       inkscape:original-d="m 53.977047,64.626543 c 1.45085,-0.929703 4.263747,0.764231 5.806357,0 2.01218,-0.99686 7.087937,-5.250989 8.290967,-7.37526 0.917747,-1.620525 -0.11504,-3.737666 0.713137,-5.388819" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 45.824023,64.647305 7.853886,44.476685"
+       id="path3096" />
+    <ellipse
+       style="fill:#9558b2;fill-opacity:1;fill-rule:evenodd;stroke-width:0.271582"
+       id="path239-6-7"
+       cx="44.204033"
+       cy="60.897579"
+       rx="10.2645"
+       ry="10.264584" />
+    <ellipse
+       style="fill:#9558b2;fill-opacity:1;fill-rule:evenodd;stroke-width:0.271582"
+       id="path239-6-7-4"
+       cx="40.898346"
+       cy="73.190628"
+       rx="10.2645"
+       ry="10.264584"
+       transform="rotate(-30)" />
+  </g>
+</svg>


### PR DESCRIPTION
I added files of the Juleana logo without the "Juleana" text,
which might be convenient for composing slides or watermarking Plots composed with the LEGEND Julia Software Stack.

# Logo circle
![logo-circle](https://github.com/user-attachments/assets/afd875fe-f4d6-4b3a-9204-96993e20dc5f)

# Logo no text
![logo-notext](https://github.com/user-attachments/assets/270d8622-754f-4026-ae14-aa7f14523da6)
